### PR TITLE
Feature/django18support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.3.1
+-----
+
+* Adding MANIFEST.in file to define which files get included in the source
+  distribution. CHANGES.rst was missing from that and caused an error on
+  install.
+
 0.3.0
 -----
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.rst
+include CHANGES.rst

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*parts):
 
 setup(
     name = "django_deferred_polymorph",
-    version = "0.3.0",
+    version = "0.3.1",
     description = 'Polymorphic models based on django deferred models',
     author = 'David Danier',
     author_email = 'david.danier@team23.de',


### PR DESCRIPTION
Adding `MANIFEST.in` file to define which files get included in the source distribution.  `CHANGES.rst` was missing from that and caused an error on install.
