### PR TITLE
Fix self referencing models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.3.2
+-----
+
+* Fix for Django 1.8 that did not set ``_base_manager`` correctly for
+  subclasses of ``DeferredPolymorphBaseModel``. That broke the
+  ``Model.delete()`` method in some cases.
+
 0.3.1
 -----
 

--- a/django_deferred_polymorph/models.py
+++ b/django_deferred_polymorph/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import django
+from django.db.models.signals import class_prepared
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django_deferred_polymorph.manager import DeferredPolymorphManager
@@ -7,35 +8,40 @@ from django_deferred_polymorph.manager import DeferredPolymorphManager
 
 class DeferredPolymorphBaseModel(models.Model):
     _poly_ct = models.ForeignKey(ContentType, related_name='+', editable=False)
-    
+
     objects = DeferredPolymorphManager()
     base_objects = models.Manager()
-    _base_manager = base_objects
-    
+
+    @classmethod
+    def _ensure_base_manager(cls):
+        if cls._base_manager is cls._default_manager:
+            cls._base_manager = cls.base_objects
+
     def _fill_poly_ct(self):
         if self._poly_ct_id is None:
             self._poly_ct = ContentType.objects.get_for_model(self.__class__)
-    
+
+
     def save(self, *args, **kwargs):
         self._fill_poly_ct()
         return super(DeferredPolymorphBaseModel, self).save(*args, **kwargs)
-    
+
     def get_real_instance_class(self):
         """ Use this instead of obj._poly_ct, as this call gets cached """
         return ContentType.objects.get_for_id(self._poly_ct_id).model_class()
-    
+
     def get_real_instance(self):
         model = self.get_real_instance_class()
         if self.__class__ is model: # or (self._deferred and self.__class__.__bases__[0] is model):
             return self
         return model._default_manager.get(pk = self.pk)
-    
+
     def delete(self, *args, **kwargs):
         if self._deferred:
             self.get_real_instance().delete(*args, **kwargs)
         else:
             super(DeferredPolymorphBaseModel, self).delete(*args, **kwargs)
-    
+
     class Meta:
         abstract = True
 
@@ -51,9 +57,19 @@ class SubDeferredPolymorphBaseModel(DeferredPolymorphBaseModel):
             if self.__class__.__bases__[0] is SubDeferredPolymorphBaseModel:
                 raise RuntimeError('instance may not be saved directly, use a subclass')
         return super(SubDeferredPolymorphBaseModel, self).save(*args, **kwargs)
-    
+
     class Meta:
         abstract = True
+
+
+def set_base_manager(sender, **kwargs):
+    model = sender
+
+    if issubclass(model, DeferredPolymorphBaseModel):
+        model._ensure_base_manager()
+
+
+class_prepared.connect(set_base_manager)
 
 
 from .compat import setup_fix_parent_and_child_relation

--- a/django_deferred_polymorph/models.py
+++ b/django_deferred_polymorph/models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import django
 from django.db.models.signals import class_prepared
 from django.db import models
 from django.contrib.contenttypes.models import ContentType
@@ -21,7 +20,6 @@ class DeferredPolymorphBaseModel(models.Model):
         if self._poly_ct_id is None:
             self._poly_ct = ContentType.objects.get_for_model(self.__class__)
 
-
     def save(self, *args, **kwargs):
         self._fill_poly_ct()
         return super(DeferredPolymorphBaseModel, self).save(*args, **kwargs)
@@ -34,7 +32,7 @@ class DeferredPolymorphBaseModel(models.Model):
         model = self.get_real_instance_class()
         if self.__class__ is model: # or (self._deferred and self.__class__.__bases__[0] is model):
             return self
-        return model._default_manager.get(pk = self.pk)
+        return model._default_manager.get(pk=self.pk)
 
     def delete(self, *args, **kwargs):
         if self._deferred:

--- a/django_deferred_polymorph/patch_relations.py
+++ b/django_deferred_polymorph/patch_relations.py
@@ -11,7 +11,7 @@ def fix_parent_and_child_relation(model):
 
     if not issubclass(model, DeferredPolymorphBaseModel):
         return
-    for parent, field in model._meta.parents.iteritems():
+    for parent, field in model._meta.parents.items():
         if field is None:
             # not sure, what this means
             # seems to happen for deferred classes (and subclasses?)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(*parts):
 
 setup(
     name = "django_deferred_polymorph",
-    version = "0.3.1",
+    version = "0.3.2",
     description = 'Polymorphic models based on django deferred models',
     author = 'David Danier',
     author_email = 'david.danier@team23.de',
@@ -35,4 +35,3 @@ setup(
         'Topic :: Utilities'
     ],
 )
-

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,3 +9,12 @@ class SimpleBaseModel(SubDeferredPolymorphBaseModel):
 
 class SimpleDeferredModel(SimpleBaseModel):
     child_int_field = models.IntegerField(default=0)
+
+
+class SelfReferencingBaseModel(SubDeferredPolymorphBaseModel):
+    self_fk = models.ForeignKey('self', null=True, blank=True,
+                                on_delete=models.CASCADE)
+
+
+class ChildOfSelfReferencingModel(SelfReferencingBaseModel):
+    child_int_field = models.IntegerField(default=0)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,17 @@
+from django.db import models
+from django.test import TestCase
+
+from django_deferred_polymorph.manager import DeferredPolymorphManager
+from .models import SimpleDeferredModel
+
+
+class ManagerTests(TestCase):
+    def test_default_manager_is_deferred_manager(self):
+        self.assertTrue(
+            SimpleDeferredModel._default_manager is SimpleDeferredModel.objects)
+        self.assertTrue(
+            SimpleDeferredModel._default_manager.__class__ is DeferredPolymorphManager)
+
+    def test_base_manager_is_django_default_manager(self):
+        self.assertTrue(
+            SimpleDeferredModel._base_manager.__class__ is models.Manager)

--- a/tests/test_modelapi.py
+++ b/tests/test_modelapi.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
+from .models import ChildOfSelfReferencingModel
 from .models import SimpleBaseModel
 from .models import SimpleDeferredModel
+from .models import SelfReferencingBaseModel
 
 
 class ModelAPITest(TestCase):
@@ -25,3 +27,16 @@ class ModelAPITest(TestCase):
 
         self.assertEqual(SimpleBaseModel.objects.count(), 0)
         self.assertEqual(SimpleDeferredModel.objects.count(), 0)
+
+    def test_delete_self_referencing_base_model(self):
+        obj = ChildOfSelfReferencingModel.objects.create()
+        obj.self_fk = obj
+        obj.save()
+
+        self.assertEqual(SelfReferencingBaseModel.objects.count(), 1)
+        self.assertEqual(ChildOfSelfReferencingModel.objects.count(), 1)
+
+        obj.delete()
+
+        self.assertEqual(SelfReferencingBaseModel.objects.count(), 0)
+        self.assertEqual(ChildOfSelfReferencingModel.objects.count(), 0)


### PR DESCRIPTION
We had issues in Django 1.8 were the call to `delete()` of a deferred model went into an infinite recursion. The reason was that the `_base_manager` attribute was not set correctly.

This patch fixes that and increases the version number.
